### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generate-securities-list.yml
+++ b/.github/workflows/generate-securities-list.yml
@@ -4,6 +4,9 @@ on:
     - cron: "0 0 * * 0"
 
 name: Generate Securities List
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   generate-securities-list:


### PR DESCRIPTION
Potential fix for [https://github.com/miles170/twstock-go/security/code-scanning/1](https://github.com/miles170/twstock-go/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for the workflow to function. Based on the workflow's steps:
- The `contents: write` permission is needed to commit changes to the repository.
- The `pull-requests: write` permission is required to create a pull request.
- No other permissions appear to be necessary.

The `permissions` block will be added after the `name` field (line 6) to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
